### PR TITLE
Update Azure Functions JWT Token post to handle issuer aliases

### DIFF
--- a/post/secure-azure-functions-with-jwt-token/index.html
+++ b/post/secure-azure-functions-with-jwt-token/index.html
@@ -138,7 +138,7 @@ namespace FunctionApp5
                 RequireSignedTokens = true,
                 ValidAudience = audience,
                 ValidateAudience = true,
-                ValidIssuer = issuer,
+                ValidIssuer = config.Issuer,
                 ValidateIssuer = true,
                 ValidateIssuerSigningKey = true,
                 ValidateLifetime = true,


### PR DESCRIPTION
Providers like Azure AD support supplying the issuer either by name (e.g. `example.onmicrosoft.com` or by ID). However, the OpenID Connect configuration always returns the issuer by ID. This can cause token validation to fail because the token handler is doing a simple string comparison and hence believes the issuers to be different.

To avoid this issue, set the issuer in token validation to the issuer returned by the OpenID Connect configuration.